### PR TITLE
Migrate to devtoolz-library and refactor converter URL handling

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -37,15 +37,16 @@
             ],
             "scripts": [
               "node_modules/bootstrap/dist/js/bootstrap.bundle.min.js"
-            ]
+            ],
+            "allowedCommonJsDependencies": ["devtoolz-library"]
           },
           "configurations": {
             "production": {
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "500kb",
-                  "maximumError": "1mb"
+                  "maximumWarning": "1mb",
+                  "maximumError": "2mb"
                 },
                 {
                   "type": "anyComponentStyle",
@@ -53,6 +54,11 @@
                   "maximumError": "4mb"
                 }
               ],
+              "optimization": {
+                "fonts": {
+                  "inline": false
+                }
+              },
               "outputHashing": "all"
             },
             "development": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "calculadora-dev",
-  "version": "0.0.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "calculadora-dev",
-      "version": "0.0.0",
+      "version": "1.2.1",
       "dependencies": {
         "@angular/animations": "^17.3.3",
         "@angular/common": "^17.3.3",
@@ -17,7 +17,7 @@
         "@angular/platform-browser-dynamic": "^17.3.3",
         "@angular/router": "^17.3.3",
         "bootstrap": "^5.3.3",
-        "dev-toolz.library": "^1.2.2",
+        "devtoolz-library": "^1.1.0",
         "latest": "^0.2.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
@@ -5653,10 +5653,10 @@
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "dev": true
     },
-    "node_modules/dev-toolz.library": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/dev-toolz.library/-/dev-toolz.library-1.2.2.tgz",
-      "integrity": "sha512-eqgsZY5DiMTqPHBt92/e88Fwx2OuK9D8jcIHuJmCXV+vN0G6v3/2xcBpMJ58Plr+j8lLuQG1eX3XtPYhtEZ5+g==",
+    "node_modules/devtoolz-library": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devtoolz-library/-/devtoolz-library-1.1.0.tgz",
+      "integrity": "sha512-7Xgm5Whgqxl0/sZuSwePs3suyiDOKAZBSqG+zfYUxOvLxXXAqKpsDo8O++n7PiG7E4xzCZG1pj7tArjFIQz5jA==",
       "license": "ISC"
     },
     "node_modules/di": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@angular/platform-browser-dynamic": "^17.3.3",
     "@angular/router": "^17.3.3",
     "bootstrap": "^5.3.3",
-    "dev-toolz.library": "^1.2.2",
+    "devtoolz-library": "^1.1.0",
     "latest": "^0.2.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",

--- a/src/app.config.ts
+++ b/src/app.config.ts
@@ -1,7 +1,7 @@
 import { ApplicationConfig } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { routes } from './app.routes';
-import { UnitConverterFactory } from 'dev-toolz.library';
+import { UnitConverterFactory } from 'devtoolz-library';
 
 export const appConfig: ApplicationConfig = {
   providers: [

--- a/src/converters/area/pages/area-home-page/area-home-page.component.ts
+++ b/src/converters/area/pages/area-home-page/area-home-page.component.ts
@@ -2,7 +2,7 @@ import { CommonModule } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
 import { Meta, Title } from '@angular/platform-browser';
 import { RouterModule } from '@angular/router';
-import { UnitConverterFactory } from 'dev-toolz.library';
+import { UnitConverterFactory } from 'devtoolz-library';
 import { ConverterHomePageBase } from 'src/converters/shared/pages/converter-home-page-base';
 
 @Component({

--- a/src/converters/data/pages/data-home-page/data-home-page.component.ts
+++ b/src/converters/data/pages/data-home-page/data-home-page.component.ts
@@ -2,7 +2,7 @@ import { CommonModule } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
 import { Meta, Title } from '@angular/platform-browser';
 import { RouterModule } from '@angular/router';
-import { UnitConverterFactory } from 'dev-toolz.library';
+import { UnitConverterFactory } from 'devtoolz-library';
 import { ConverterHomePageBase } from 'src/converters/shared/pages/converter-home-page-base';
 
 @Component({

--- a/src/converters/energy/pages/energy-home-page/energy-home-page.component.ts
+++ b/src/converters/energy/pages/energy-home-page/energy-home-page.component.ts
@@ -2,7 +2,7 @@ import { CommonModule } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
 import { Meta, Title } from '@angular/platform-browser';
 import { RouterModule } from '@angular/router';
-import { UnitConverterFactory } from 'dev-toolz.library';
+import { UnitConverterFactory } from 'devtoolz-library';
 import { ConverterHomePageBase } from 'src/converters/shared/pages/converter-home-page-base';
 
 @Component({

--- a/src/converters/length/pages/length-converter-home-page/length-converter-home-page.component.ts
+++ b/src/converters/length/pages/length-converter-home-page/length-converter-home-page.component.ts
@@ -2,7 +2,7 @@ import { CommonModule } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
 import { Meta, Title } from '@angular/platform-browser';
 import { RouterModule } from '@angular/router';
-import { UnitConverterFactory } from 'dev-toolz.library';
+import { UnitConverterFactory } from 'devtoolz-library';
 import { ConverterHomePageBase } from 'src/converters/shared/pages/converter-home-page-base';
 
 @Component({

--- a/src/converters/shared/components/calculator/calculator.component.ts
+++ b/src/converters/shared/components/calculator/calculator.component.ts
@@ -2,7 +2,7 @@
 import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { UnitConverterFactory, IUnitConverter, Unit } from 'dev-toolz.library';
+import { UnitConverterFactory, IUnitConverter, Unit } from 'devtoolz-library';
 import { CalculatorResult } from 'src/converters/shared/models/calculatorResult';
 
 @Component({

--- a/src/converters/shared/components/converter-title/converter-title.component.ts
+++ b/src/converters/shared/components/converter-title/converter-title.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, input } from '@angular/core';
-import { Unit } from 'dev-toolz.library';
+import { Unit } from 'devtoolz-library';
 
 @Component({
   selector: 'converter-title',

--- a/src/converters/shared/pages/converter-home-page-base.ts
+++ b/src/converters/shared/pages/converter-home-page-base.ts
@@ -1,5 +1,5 @@
 import { Meta, Title } from "@angular/platform-browser";
-import { UnitConverterFactory, IUnitConverter, Unit } from "dev-toolz.library";
+import { UnitConverterFactory, IUnitConverter, Unit } from "devtoolz-library";
 import { NavigationHelper } from "src/shared/helpers/navigationHelper";
 import { PageBase } from "src/shared/pages/pageBase";
 import { UnitUrlFormatterService } from '../services/unit-url-formatter.service';

--- a/src/converters/shared/pages/converter-page-base.ts
+++ b/src/converters/shared/pages/converter-page-base.ts
@@ -1,4 +1,4 @@
-import { UnitConverterFactory, IUnitConverter, Unit } from "dev-toolz.library";
+import { UnitConverterFactory, IUnitConverter, Unit } from "devtoolz-library";
 import { PageBase } from "src/shared/pages/pageBase"
 import { UnitUrlFormatterService } from "../services/unit-url-formatter.service";
 import { inject } from "@angular/core";

--- a/src/converters/shared/services/converter-base/converter-base.service.ts
+++ b/src/converters/shared/services/converter-base/converter-base.service.ts
@@ -1,22 +1,19 @@
 import { Optional } from '@angular/core';
-import { ConverterFactory, IConverter } from 'dev-toolz.library';
+import { UnitConverterFactory, IUnitConverter } from 'devtoolz-library';
 import { ConverterUrlService } from '../converter-url-service/converter-url.service';
 
 // @Injectable({
 //   providedIn: 'root'
 // })
 export class ConvertersBaseService {
-  protected converter: IConverter;
-  protected converterFactory: ConverterFactory = new ConverterFactory();
+  protected converter: IUnitConverter;
+  protected converterFactory: UnitConverterFactory = new UnitConverterFactory();
 
   constructor(
     protected categoryId: string,
     @Optional() protected urlService?: ConverterUrlService
   ) {
-    this.converter = this.converterFactory.getConverter(categoryId);
-    if (this.urlService) {
-      this.urlService.units = this.converter.getUnits();
-    }
+    this.converter = this.converterFactory.createService(categoryId);
   }
 
   getUnits() {
@@ -32,10 +29,14 @@ export class ConvertersBaseService {
   }
 
   generateConversionUrl(sourceUnitId: string, targetUnitId: string): string {
-    return this.urlService?.generateConversionUrl(sourceUnitId, targetUnitId) || '';
+    if (!this.urlService) return '';
+    const sourceUnit = this.converter.getUnitById(sourceUnitId);
+    const targetUnit = this.converter.getUnitById(targetUnitId);
+    if (!sourceUnit || !targetUnit) return '';
+    return this.urlService.generateConversionUrl(sourceUnit, targetUnit);
   }
 
   parseConversionUrl(url: string) {
-    return this.urlService?.parseConversionUrl(url);
+    return this.urlService?.parseConversionUrl(this.converter.getUnits(), url);
   }
 }

--- a/src/converters/shared/services/converter-url-service/converter-url.service.ts
+++ b/src/converters/shared/services/converter-url-service/converter-url.service.ts
@@ -1,6 +1,6 @@
 // src/converters/shared/services/converter-url/converter-url.service.ts
 import { Injectable } from '@angular/core';
-import { Unit } from 'dev-toolz.library';
+import { Unit } from 'devtoolz-library';
 
 @Injectable({
     providedIn: 'root'

--- a/src/converters/temperature/pages/temperature-converter-home-page/temperature-converter-home-page.component.ts
+++ b/src/converters/temperature/pages/temperature-converter-home-page/temperature-converter-home-page.component.ts
@@ -2,7 +2,7 @@ import { CommonModule } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
 import { Meta, Title } from '@angular/platform-browser';
 import { RouterModule } from '@angular/router';
-import { UnitConverterFactory } from 'dev-toolz.library';
+import { UnitConverterFactory } from 'devtoolz-library';
 import { ConverterHomePageBase } from 'src/converters/shared/pages/converter-home-page-base';
 
 @Component({

--- a/src/converters/volume/pages/volume-home-page/volume-page/volume-page.component.ts
+++ b/src/converters/volume/pages/volume-home-page/volume-page/volume-page.component.ts
@@ -2,7 +2,7 @@ import { CommonModule } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
 import { Meta, Title } from '@angular/platform-browser';
 import { RouterModule } from '@angular/router';
-import { UnitConverterFactory } from 'dev-toolz.library';
+import { UnitConverterFactory } from 'devtoolz-library';
 import { ConverterHomePageBase } from 'src/converters/shared/pages/converter-home-page-base';
 
 @Component({

--- a/src/converters/weight-and-mass/pages/weight-mass-page/weight-mass-page.component.ts
+++ b/src/converters/weight-and-mass/pages/weight-mass-page/weight-mass-page.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { Meta, Title } from '@angular/platform-browser';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
-import { UnitConverterFactory } from 'dev-toolz.library';
+import { UnitConverterFactory } from 'devtoolz-library';
 import { ConverterHomePageBase } from 'src/converters/shared/pages/converter-home-page-base';
 
 @Component({


### PR DESCRIPTION
## Summary
This PR updates the library dependency from `dev-toolz.library` to `devtoolz-library` and refactors the converter URL service integration to improve type safety and separation of concerns.

## Key Changes

- **Dependency Migration**: Updated all imports from `dev-toolz.library` to `devtoolz-library` across the entire codebase
- **API Updates**: 
  - Renamed `ConverterFactory` to `UnitConverterFactory`
  - Renamed `IConverter` to `IUnitConverter`
  - Updated factory method from `getConverter()` to `createService()`
- **Converter Base Service Refactoring**:
  - Removed automatic URL service initialization from constructor
  - Enhanced `generateConversionUrl()` to resolve unit IDs to unit objects before passing to URL service
  - Updated `parseConversionUrl()` to pass converter units as a parameter
- **Build Configuration**:
  - Added `devtoolz-library` to `allowedCommonJsDependencies` in Angular build config
  - Increased production bundle size budgets (initial: 500kb→1mb, error: 1mb→2mb)
  - Disabled font inlining optimization in production builds
- **Package Updates**: Downgraded `devtoolz-library` from v1.2.2 to v1.1.0

## Implementation Details

The refactoring improves the converter URL service by making it work with strongly-typed `Unit` objects rather than string IDs, reducing the coupling between services and making the code more maintainable.

https://claude.ai/code/session_0148r6n7biDHhTMTq1kydLgz