### PR TITLE
Add validation for unit conversion URL parameters

### DIFF
--- a/src/converters/shared/pages/converter-page-base.ts
+++ b/src/converters/shared/pages/converter-page-base.ts
@@ -56,8 +56,16 @@ export class ConverterPageBase extends PageBase {
             if (conversionParam) {
                 const conversionInfo = this.unitUrlFormatter.parseConversionUrl(conversionParam);
                 if (conversionInfo) {
-                    this.selectedSourceUnit = this.service.getUnitById(conversionInfo.sourceUnitId)!;
-                    this.selectedTargetUnit = this.service.getUnitById(conversionInfo.targetUnitId)!;
+                    const sourceUnit = this.service.getUnitById(conversionInfo.sourceUnitId);
+                    const targetUnit = this.service.getUnitById(conversionInfo.targetUnitId);
+
+                    if (!sourceUnit || !targetUnit) {
+                        this.router.navigate(['/conversores/' + this.urlPrefix]);
+                        return;
+                    }
+
+                    this.selectedSourceUnit = sourceUnit;
+                    this.selectedTargetUnit = targetUnit;
                     this.updateTitle();
                     // this.gerarConversoesSugeridas();
                 } else {

--- a/src/converters/shared/services/unit-url-formatter.service.ts
+++ b/src/converters/shared/services/unit-url-formatter.service.ts
@@ -39,6 +39,9 @@ export class UnitUrlFormatterService {
   // Método para auxiliar a converter entre a URL e os IDs das unidades
   parseConversionUrl(url: string): { sourceUnitId: string, targetUnitId: string } | undefined {
     // Formato esperado: unidade-origem-para-unidade-destino
+    if (!url.startsWith('converter-'))
+      return undefined;
+
     const parts = url.substring('converter-'.length).split('-para-');
 
     if (parts.length !== 2)


### PR DESCRIPTION
## Summary
This PR adds proper validation and error handling for unit conversion URL parameters to prevent runtime errors when invalid or malformed conversion URLs are provided.

## Key Changes
- **ConverterPageBase**: Added null checks for source and target units retrieved from the service. If either unit is not found, the application now navigates back to the converter home page instead of attempting to use null values.
- **UnitUrlFormatterService**: Added validation to ensure the URL starts with the expected 'converter-' prefix before attempting to parse it. Returns `undefined` if the prefix is missing, allowing the caller to handle invalid URLs gracefully.

## Implementation Details
- The validation prevents the non-null assertion operator (`!`) from masking potential null values, improving type safety
- Invalid conversion URLs now result in a redirect to the converter home page rather than a runtime error
- The URL format validation is now explicit and documented through the early return pattern

https://claude.ai/code/session_01TWZxfEVU5zmNXFHQ6e4UG4