### PR TITLE
feat: implementa conversor de pressão

### DIFF
--- a/src/converters/pressure/pages/pressure-converter-page/pressure-converter-page.component.html
+++ b/src/converters/pressure/pages/pressure-converter-page/pressure-converter-page.component.html
@@ -1,0 +1,73 @@
+<div class="page-container">
+  <nav class="breadcrumbs">
+    <ol>
+      <li><a routerLink="/">Início</a></li>
+      <li><a routerLink="/conversores">Conversores</a></li>
+      <li><a routerLink="/conversores/pressao">Pressão</a></li>
+      <li><span>Converter {{selectedSourceUnit.name}} para {{selectedTargetUnit.name}}</span></li>
+    </ol>
+  </nav>
+
+  <converter-title [sourceUnit]="selectedSourceUnit" [targetUnit]="selectedTargetUnit" />
+
+  <!-- Instruções de uso -->
+  <div class="card mb-4">
+    <div class="card-body">
+      <h2 class="card-title fs-4">
+        Como usar a ferramenta de conversão de {{selectedSourceUnit.name.toLowerCase()}} para
+        {{selectedTargetUnit.name.toLowerCase()}}
+      </h2>
+      <p>
+        Esta calculadora permite converter entre diversas unidades de pressão, incluindo Pascal, Bar, Atmosfera padrão,
+        Quilopascal, Milímetro de mercúrio (mmHg) e Libra por polegada quadrada (PSI).
+        Basta selecionar as unidades de origem e destino, inserir o valor desejado e o sistema
+        calculará automaticamente o resultado com base nos fatores de conversão apropriados.
+      </p>
+      <ol>
+        <li>Escolha a unidade de origem (de onde deseja converter)</li>
+        <li>Escolha a unidade de destino (para onde deseja converter)</li>
+        <li>Digite o valor na unidade de origem</li>
+        <li>O resultado será calculado automaticamente</li>
+      </ol>
+    </div>
+  </div>
+
+  <!-- Componente de calculadora -->
+  <calculator [selectedCategoryId]="selectedCategory" [selectedSourceUnitId]="selectedSourceUnit.id"
+    [selectedTargetUnitId]="selectedTargetUnit.id" (sourceUnitChange)="onSourceUnitChange($event)"
+    (targetUnitChange)="onTargetUnitChange($event)" (valueChange)="onValueChange($event)">
+  </calculator>
+
+  <!-- Explicação da fórmula de cálculo -->
+  <div class="mt-5 card" *ngIf="showFormula">
+    <div class="card-body">
+      <h2 class="card-title fs-4">Explicação do Cálculo</h2>
+      <p>{{ formulaDescription }}</p>
+      <div class="bg-dark text-light p-3 rounded">
+        <pre class="mb-0">{{ formulaCalculation }}</pre>
+      </div>
+    </div>
+  </div>
+
+  <!-- Informações adicionais -->
+  <div class="mt-5">
+    <h2 class="text-center fs-4">Informações sobre Unidades de Pressão</h2>
+    <div class="texto-explicativo">
+      <p>
+        A pressão é a força exercida por unidade de área sobre uma superfície.
+        Existem diferentes unidades utilizadas para medir pressão ao redor do mundo:
+      </p>
+      <ul>
+        <li><strong>Pascal (Pa)</strong>: unidade do Sistema Internacional (SI), equivale a 1 Newton por metro quadrado</li>
+        <li><strong>Quilopascal (kPa)</strong>: equivale a 1.000 Pascais, muito usado em meteorologia e engenharia</li>
+        <li><strong>Bar (bar)</strong>: aproximadamente igual à pressão atmosférica ao nível do mar; 1 bar = 100.000 Pa</li>
+        <li><strong>Atmosfera padrão (atm)</strong>: pressão atmosférica ao nível do mar; 1 atm = 101.325 Pa</li>
+        <li><strong>Milímetro de mercúrio (mmHg)</strong>: unidade tradicional usada na medicina para medir pressão arterial; 1 mmHg ≈ 133,32 Pa</li>
+        <li><strong>Libra por polegada quadrada (PSI)</strong>: unidade do sistema imperial amplamente usada nos EUA para pneus e sistemas hidráulicos; 1 PSI ≈ 6.894,76 Pa</li>
+      </ul>
+      <p>
+        Todas as conversões são realizadas com alta precisão, utilizando o Pascal como unidade base conforme o Sistema Internacional de Unidades.
+      </p>
+    </div>
+  </div>
+</div>

--- a/src/converters/pressure/pages/pressure-converter-page/pressure-converter-page.component.scss
+++ b/src/converters/pressure/pages/pressure-converter-page/pressure-converter-page.component.scss
@@ -1,0 +1,1 @@
+@import url('../../../shared/converter.style.scss');

--- a/src/converters/pressure/pages/pressure-converter-page/pressure-converter-page.component.ts
+++ b/src/converters/pressure/pages/pressure-converter-page/pressure-converter-page.component.ts
@@ -1,0 +1,32 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+import { CalculatorComponent } from 'src/converters/shared/components/calculator/calculator.component';
+import { ConverterPageBase } from 'src/converters/shared/pages/converter-page-base';
+import { ConverterTitleComponent } from 'src/converters/shared/components/converter-title/converter-title.component';
+
+@Component({
+  selector: 'pressure-converter-page',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    RouterModule,
+    CalculatorComponent,
+    ConverterTitleComponent
+  ],
+  templateUrl: './pressure-converter-page.component.html',
+  styleUrl: './pressure-converter-page.component.scss'
+})
+export class PressureConverterPageComponent extends ConverterPageBase implements OnInit {
+  constructor() {
+    super("pressure", "pressao");
+    this.setTitle('Conversor de Pressão');
+    this.addDescription('Ferramenta para converter entre diferentes unidades de pressão como Pascal, Bar, Atmosfera, Quilopascal, Milímetro de mercúrio e PSI. Conversão precisa, instantânea e confiável.');
+  }
+
+  ngOnInit(): void {
+    this.onInit('pascal', 'bar');
+  }
+}

--- a/src/converters/pressure/pages/pressure-home-page/pressure-home-page.component.html
+++ b/src/converters/pressure/pages/pressure-home-page/pressure-home-page.component.html
@@ -1,0 +1,65 @@
+<div class="page-container">
+    <!-- Breadcrumbs -->
+    <nav class="breadcrumbs">
+        <ol>
+            <li><a routerLink="/">Início</a></li>
+            <li><a routerLink="/conversores">Conversores</a></li>
+            <li><span>Pressão</span></li>
+        </ol>
+    </nav>
+
+    <!-- Título da Subcategoria -->
+    <div class="category-header">
+        <div class="category-icon">
+            <span class="material-symbols-outlined">compress</span>
+        </div>
+        <div class="category-info">
+            <h1>Conversor de Pressão</h1>
+            <p>Faça conversões precisas entre diferentes unidades de pressão</p>
+        </div>
+    </div>
+
+    <!-- Descrição da Subcategoria -->
+    <section class="category-description">
+        <div class="description-content">
+            <p>O conversor de pressão permite transformar valores entre diversas unidades de pressão, como Pascal,
+                Bar, Atmosfera padrão, Quilopascal, Milímetro de mercúrio (mmHg) e Libra por polegada quadrada (PSI),
+                com total precisão e confiabilidade.</p>
+            <p>Ideal para estudantes, profissionais de física, engenharia, medicina ou qualquer pessoa que precise
+                converter pressões entre os diferentes sistemas de medição.</p>
+        </div>
+    </section>
+
+    <!-- Links de conversão agrupados por unidade de medida -->
+    <section class="conversion-groups-container">
+        @for(item of groupedUnits; track item.key.id) {
+        <section class="conversion-group" [id]="item.key.id">
+            <h2>Conversões de {{item.key.name}} ({{item.key.symbol}})</h2>
+            <hr>
+            <div class="conversion-links-grid">
+                @for(unit of item.units; track unit.id) {
+                <a [routerLink]="['/conversores/pressao', unitUrlFormatterService.generateConversionUrl(item.key.id, unit.id)]"
+                    class="conversion-link-card">
+                    <div class="conversion-link-icon">
+                        <span class="material-symbols-outlined">compress</span>
+                    </div>
+                    <div class="conversion-link-content">
+                        <h3>{{item.key.name}} para {{ unit.name }}</h3>
+                    </div>
+                </a>
+                }
+            </div>
+        </section>
+        }
+    </section>
+
+    <!-- Índice de navegação rápida -->
+    <section class="quick-navigation">
+        <h2>Navegação Rápida</h2>
+        <div class="quick-nav-list">
+            @for(item of groupedUnits; track item.key.id){
+            <a [href]="'#' + item.key.id" class="unit-chip">{{item.key.name}}</a>
+            }
+        </div>
+    </section>
+</div>

--- a/src/converters/pressure/pages/pressure-home-page/pressure-home-page.component.scss
+++ b/src/converters/pressure/pages/pressure-home-page/pressure-home-page.component.scss
@@ -1,0 +1,1 @@
+@import url('../../../shared/converter.style.scss');

--- a/src/converters/pressure/pages/pressure-home-page/pressure-home-page.component.ts
+++ b/src/converters/pressure/pages/pressure-home-page/pressure-home-page.component.ts
@@ -1,0 +1,36 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { ConverterHomePageBase } from 'src/converters/shared/pages/converter-home-page-base';
+
+@Component({
+  selector: 'pressure-home-page',
+  standalone: true,
+  imports: [
+    RouterModule,
+    CommonModule,
+  ],
+  templateUrl: './pressure-home-page.component.html',
+  styleUrl: './pressure-home-page.component.scss'
+})
+export class PressureHomePageComponent extends ConverterHomePageBase implements OnInit {
+  constructor() {
+    super("pressure");
+  }
+
+  ngOnInit() {
+    const pageTitle = 'Conversor de Pressão';
+    const description = 'Converta facilmente entre diferentes unidades de pressão como Pascal, Bar, Atmosfera, Quilopascal, Milímetro de mercúrio e PSI. Calculadora precisa com explicações detalhadas e conversões confiáveis.';
+    const keywords = 'conversor de pressão, pascal para bar, bar para atmosfera, quilopascal, milímetro de mercúrio, psi, conversão de pressão, calculadora de pressão';
+
+    this.onInit(
+      pageTitle,
+      description,
+      keywords,
+    );
+  }
+
+  ngAfterViewInit() {
+    this.navigationHelper();
+  }
+}

--- a/src/converters/pressure/pressure.routes.ts
+++ b/src/converters/pressure/pressure.routes.ts
@@ -1,0 +1,8 @@
+import { Routes } from '@angular/router';
+import { PressureHomePageComponent } from './pages/pressure-home-page/pressure-home-page.component';
+import { PressureConverterPageComponent } from './pages/pressure-converter-page/pressure-converter-page.component';
+
+export const PRESSURE_ROUTES: Routes = [
+    { path: '', component: PressureHomePageComponent },
+    { path: ':conversion', component: PressureConverterPageComponent }
+];

--- a/src/converters/shared/converters.routes.ts
+++ b/src/converters/shared/converters.routes.ts
@@ -15,4 +15,5 @@ export const CONVERTERS_ROUTES: Routes = [
     { path: 'sistemas-numericos', loadChildren: () => import('../numeric-systems/numeric-systems.routes').then(m => m.NUMERIC_SYSTEMS_ROUTES) },
     { path: 'texto-para-binario', loadChildren: () => import('../texto-binario/texto-binario.routes').then(m => m.TEXTO_BINARIO_ROUTES) },
     { path: 'angulo', loadChildren: () => import('../angle/angle.routes').then(m => m.ANGLE_ROUTES) },
+    { path: 'pressao', loadChildren: () => import('../pressure/pressure.routes').then(m => m.PRESSURE_ROUTES) },
 ];

--- a/src/converters/shared/pages/converters-page/converters-page.component.ts
+++ b/src/converters/shared/pages/converters-page/converters-page.component.ts
@@ -22,6 +22,7 @@ export class ConvertersPageComponent extends PageBase implements OnInit {
     { id: 'dados', name: 'Dados', icon: 'database' },
     { id: 'energia', name: 'Energia', icon: 'bolt' },
     { id: 'peso-e-massa', name: 'Peso e Massa', icon: 'weight' },
+    { id: 'pressao', name: 'Pressão', icon: 'compress' },
     { id: 'sistemas-numericos', name: 'Sistemas Numéricos', icon: 'tag' },
     { id: 'temperatura', name: 'Temperatura', icon: 'device_thermostat' },
     { id: 'tempo-decimal', name: 'Tempo Decimal', icon: 'speed_1_75' },


### PR DESCRIPTION
## Resumo

Implementa o conversor de pressão conforme solicitado na issue #110.

- Adiciona home page com listagem de conversões agrupadas por unidade
- Adiciona página de conversão com calculadora interativa e explicação de fórmulas
- Registra a rota `/conversores/pressao` no roteamento da aplicação
- Adiciona a categoria "Pressão" na página principal de conversores

## Unidades suportadas

- Pascal (Pa) — unidade base
- Quilopascal (kPa)
- Bar (bar)
- Atmosfera padrão (atm)
- Milímetro de mercúrio (mmHg)
- Libra por polegada quadrada (PSI)

## Checklist

- [x] Home page com navegação rápida e grupos de conversão
- [x] Página de conversor com calculadora e fórmula detalhada
- [x] Rota lazy-loaded registrada em `converters.routes.ts`
- [x] Categoria adicionada na `converters-page`
- [x] Padrão do projeto seguido (herança de `ConverterHomePageBase` e `ConverterPageBase`)

Closes #110

https://claude.ai/code/session_017JGmPyaHSXC9mGcyt1e1YB