### PR TITLE
Add speed unit converter with home and detail pages

### DIFF
--- a/src/converters/shared/converters.routes.ts
+++ b/src/converters/shared/converters.routes.ts
@@ -16,4 +16,5 @@ export const CONVERTERS_ROUTES: Routes = [
     { path: 'texto-para-binario', loadChildren: () => import('../texto-binario/texto-binario.routes').then(m => m.TEXTO_BINARIO_ROUTES) },
     { path: 'angulo', loadChildren: () => import('../angle/angle.routes').then(m => m.ANGLE_ROUTES) },
     { path: 'pressao', loadChildren: () => import('../pressure/pressure.routes').then(m => m.PRESSURE_ROUTES) },
+    { path: 'velocidade', loadChildren: () => import('../speed/speed.routes').then(m => m.SPEED_ROUTES) },
 ];

--- a/src/converters/shared/pages/converters-page/converters-page.component.ts
+++ b/src/converters/shared/pages/converters-page/converters-page.component.ts
@@ -27,6 +27,7 @@ export class ConvertersPageComponent extends PageBase implements OnInit {
     { id: 'temperatura', name: 'Temperatura', icon: 'device_thermostat' },
     { id: 'tempo-decimal', name: 'Tempo Decimal', icon: 'speed_1_75' },
     { id: 'texto-para-binario', name: 'Texto para Binário', icon: 'text_fields' },
+    { id: 'velocidade', name: 'Velocidade', icon: 'speed' },
     { id: 'volume', name: 'Volume', icon: 'deployed_code' },
   ];
 

--- a/src/converters/speed/pages/speed-converter-home-page/speed-converter-home-page.component.html
+++ b/src/converters/speed/pages/speed-converter-home-page/speed-converter-home-page.component.html
@@ -1,0 +1,65 @@
+<div class="page-container">
+    <!-- Breadcrumbs -->
+    <nav class="breadcrumbs">
+        <ol>
+            <li><a routerLink="/">Início</a></li>
+            <li><a routerLink="/conversores">Conversores</a></li>
+            <li><span>Velocidade</span></li>
+        </ol>
+    </nav>
+
+    <!-- Título da Subcategoria -->
+    <div class="category-header">
+        <div class="category-icon">
+            <span class="material-symbols-outlined">speed</span>
+        </div>
+        <div class="category-info">
+            <h1>Conversor de Velocidade</h1>
+            <p>Faça conversões precisas entre diferentes unidades de velocidade</p>
+        </div>
+    </div>
+
+    <!-- Descrição da Subcategoria -->
+    <section class="category-description">
+        <div class="description-content">
+            <p>O conversor de velocidade permite transformar valores entre diversas unidades, como metros por segundo,
+                quilômetros por hora, milhas por hora, nós náuticos, Mach e velocidade da luz, com total precisão e confiabilidade.</p>
+            <p>Ideal para estudantes, profissionais de física, engenharia, meteorologia, aviação ou qualquer pessoa que
+                precise converter velocidades entre sistemas científicos e práticos de medição.</p>
+        </div>
+    </section>
+
+
+    <!-- Links de conversão agrupados por unidade de medida -->
+    <section class="conversion-groups-container">
+        @for(item of groupedUnits; track item.key.id) {
+        <section class="conversion-group" [id]="item.key.id">
+            <h2>Conversões de {{item.key.name}} ({{item.key.symbol}})</h2>
+            <hr>
+            <div class="conversion-links-grid">
+                @for(unit of item.units; track unit.id) {
+                <a [routerLink]="['/conversores/velocidade', unitUrlFormatterService.generateConversionUrl(item.key.id, unit.id)]"
+                    class="conversion-link-card">
+                    <div class="conversion-link-icon">
+                        <span class="material-symbols-outlined">speed</span>
+                    </div>
+                    <div class="conversion-link-content">
+                        <h3>{{item.key.name}} para {{ unit.name }}</h3>
+                    </div>
+                </a>
+                }
+            </div>
+        </section>
+        }
+    </section>
+
+    <!-- Índice de navegação rápida -->
+    <section class="quick-navigation">
+        <h2>Navegação Rápida</h2>
+        <div class="quick-nav-list">
+            @for(item of groupedUnits; track item.key.id){
+            <a [href]="'#' + item.key.id" class="unit-chip">{{item.key.name}}</a>
+            }
+        </div>
+    </section>
+</div>

--- a/src/converters/speed/pages/speed-converter-home-page/speed-converter-home-page.component.scss
+++ b/src/converters/speed/pages/speed-converter-home-page/speed-converter-home-page.component.scss
@@ -1,0 +1,1 @@
+@import url('../../../shared/converter.style.scss');

--- a/src/converters/speed/pages/speed-converter-home-page/speed-converter-home-page.component.spec.ts
+++ b/src/converters/speed/pages/speed-converter-home-page/speed-converter-home-page.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SpeedConverterHomePageComponent } from './speed-converter-home-page.component';
+
+describe('SpeedConverterHomePageComponent', () => {
+  let component: SpeedConverterHomePageComponent;
+  let fixture: ComponentFixture<SpeedConverterHomePageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SpeedConverterHomePageComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(SpeedConverterHomePageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/converters/speed/pages/speed-converter-home-page/speed-converter-home-page.component.ts
+++ b/src/converters/speed/pages/speed-converter-home-page/speed-converter-home-page.component.ts
@@ -1,0 +1,38 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { Meta, Title } from '@angular/platform-browser';
+import { RouterModule } from '@angular/router';
+import { UnitConverterFactory } from 'devtoolz-library';
+import { ConverterHomePageBase } from 'src/converters/shared/pages/converter-home-page-base';
+
+@Component({
+  selector: 'speed-converter-home-page',
+  standalone: true,
+  imports: [
+    RouterModule,
+    CommonModule,
+  ],
+  templateUrl: './speed-converter-home-page.component.html',
+  styleUrl: './speed-converter-home-page.component.scss'
+})
+export class SpeedConverterHomePageComponent extends ConverterHomePageBase implements OnInit {
+  constructor() {
+    super("speed");
+  }
+
+  ngOnInit() {
+    const pageTitle = 'Conversor de Velocidade';
+    const description = 'Converta facilmente entre diferentes unidades de velocidade como metros por segundo, quilômetros por hora, milhas por hora, nós, Mach e velocidade da luz. Calculadora precisa com explicações detalhadas e conversões confiáveis.';
+    const keywords = 'conversor de velocidade, metros por segundo, quilômetros por hora, milhas por hora, nós, Mach, velocidade da luz, km/h, mph, m/s, conversão de velocidade';
+
+    this.onInit(
+      pageTitle,
+      description,
+      keywords,
+    );
+  }
+
+  ngAfterViewInit() {
+    this.navigationHelper();
+  }
+}

--- a/src/converters/speed/pages/speed-converter-page/speed-converter-page.component.html
+++ b/src/converters/speed/pages/speed-converter-page/speed-converter-page.component.html
@@ -1,0 +1,79 @@
+<div class="page-container">
+  <nav class="breadcrumbs">
+    <ol>
+      <li><a routerLink="/">Início</a></li>
+      <li><a routerLink="/conversores">Conversores</a></li>
+      <li><a routerLink="/conversores/velocidade">Velocidade</a></li>
+      <li><span>Converter {{selectedSourceUnit.name}} para {{selectedTargetUnit.name}}</span></li>
+    </ol>
+  </nav>
+
+  <converter-title [sourceUnit]="selectedSourceUnit" [targetUnit]="selectedTargetUnit" />
+
+  <!-- Instruções de uso -->
+  <div class="card mb-4">
+    <div class="card-body">
+      <h2 class="card-title fs-4">
+        Como usar a ferramenta de conversão de {{selectedSourceUnit.name.toLowerCase()}} para
+        {{selectedTargetUnit.name.toLowerCase()}}
+      </h2>
+      <p>
+        Esta calculadora permite converter entre diversas unidades de velocidade, incluindo metros por segundo,
+        quilômetros por hora, milhas por hora, nós náuticos, Mach e velocidade da luz. Basta selecionar as unidades
+        de origem e destino, inserir o valor desejado e o sistema calculará automaticamente o resultado.
+      </p>
+      <ol>
+        <li>Escolha a unidade de origem (de onde deseja converter)</li>
+        <li>Escolha a unidade de destino (para onde deseja converter)</li>
+        <li>Digite o valor na unidade de origem</li>
+        <li>O resultado será calculado automaticamente</li>
+      </ol>
+    </div>
+  </div>
+
+  <!-- Componente de calculadora -->
+  <calculator [selectedCategoryId]="selectedCategory" [selectedSourceUnitId]="selectedSourceUnit.id"
+    [selectedTargetUnitId]="selectedTargetUnit.id" (sourceUnitChange)="onSourceUnitChange($event)"
+    (targetUnitChange)="onTargetUnitChange($event)" (valueChange)="onValueChange($event)">
+  </calculator>
+
+  <!-- Explicação da fórmula de cálculo -->
+  <div class="mt-5 card" *ngIf="showFormula">
+    <div class="card-body">
+      <h2 class="card-title fs-4">Explicação do Cálculo</h2>
+      <p>{{ formulaDescription }}</p>
+      <div class="bg-dark text-light p-3 rounded">
+        <pre class="mb-0">{{ formulaCalculation }}</pre>
+      </div>
+    </div>
+  </div>
+
+  <!-- Informações adicionais -->
+  <div class="mt-5">
+    <h2 class="text-center fs-4">Informações sobre Unidades de Velocidade</h2>
+    <div class="texto-explicativo">
+      <p>
+        A velocidade é uma grandeza física que expressa a variação da posição de um corpo em relação ao tempo.
+        Ela está presente em diversos contextos científicos, industriais, esportivos e cotidianos.
+        Existem diferentes unidades utilizadas para medir velocidade ao redor do mundo:
+      </p>
+      <ul>
+        <li><strong>Metro por segundo (m/s)</strong>: unidade padrão do Sistema Internacional de Unidades (SI)</li>
+        <li><strong>Quilômetro por hora (km/h)</strong>: amplamente utilizada no cotidiano, especialmente em transportes terrestres</li>
+        <li><strong>Milha por hora (mph)</strong>: comum nos Estados Unidos e no Reino Unido</li>
+        <li><strong>Nó náutico (kn)</strong>: utilizada na navegação marítima e aérea</li>
+        <li><strong>Mach</strong>: razão entre a velocidade do objeto e a velocidade do som, usada em aeronáutica</li>
+        <li><strong>Velocidade da luz (c)</strong>: constante fundamental da física, aproximadamente 299.792.458 m/s no vácuo</li>
+        <li><strong>Quilômetro por segundo (km/s)</strong>: usada em contextos astronômicos e espaciais</li>
+        <li><strong>Centímetro por segundo (cm/s)</strong>: utilizada em contextos científicos para pequenas velocidades</li>
+        <li><strong>Pés por segundo (ft/s)</strong>: unidade do sistema imperial, comum em engenharia nos EUA</li>
+        <li><strong>Polegada por segundo (in/s)</strong>: utilizada em contextos técnicos de precisão</li>
+      </ul>
+      <p>
+        Todas as conversões são realizadas com alta precisão, utilizando o metro por segundo (m/s) como unidade base
+        conforme o Sistema Internacional de Unidades.
+      </p>
+    </div>
+  </div>
+
+</div>

--- a/src/converters/speed/pages/speed-converter-page/speed-converter-page.component.scss
+++ b/src/converters/speed/pages/speed-converter-page/speed-converter-page.component.scss
@@ -1,0 +1,1 @@
+@import url('../../../shared/converter.style.scss');

--- a/src/converters/speed/pages/speed-converter-page/speed-converter-page.component.spec.ts
+++ b/src/converters/speed/pages/speed-converter-page/speed-converter-page.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SpeedConverterPageComponent } from './speed-converter-page.component';
+
+describe('SpeedConverterPageComponent', () => {
+  let component: SpeedConverterPageComponent;
+  let fixture: ComponentFixture<SpeedConverterPageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SpeedConverterPageComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(SpeedConverterPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/converters/speed/pages/speed-converter-page/speed-converter-page.component.ts
+++ b/src/converters/speed/pages/speed-converter-page/speed-converter-page.component.ts
@@ -1,0 +1,33 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Meta, Title } from '@angular/platform-browser';
+import { RouterModule } from '@angular/router';
+import { CalculatorComponent } from 'src/converters/shared/components/calculator/calculator.component';
+import { ConverterPageBase } from 'src/converters/shared/pages/converter-page-base';
+import { ConverterTitleComponent } from "src/converters/shared/components/converter-title/converter-title.component";
+
+@Component({
+  selector: 'speed-converter-page',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    RouterModule,
+    CalculatorComponent,
+    ConverterTitleComponent
+  ],
+  templateUrl: './speed-converter-page.component.html',
+  styleUrl: './speed-converter-page.component.scss'
+})
+export class SpeedConverterPageComponent extends ConverterPageBase implements OnInit {
+  constructor() {
+    super("speed", "velocidade");
+    this.setTitle('Conversor de Velocidade');
+    this.addDescription('Ferramenta para converter entre diferentes unidades de velocidade como metros por segundo, quilômetros por hora, milhas por hora, nós, Mach e velocidade da luz. Conversão precisa, instantânea e confiável.');
+  }
+
+  ngOnInit(): void {
+    this.onInit('metro-por-segundo', 'quilometro-por-hora');
+  }
+}

--- a/src/converters/speed/speed.routes.ts
+++ b/src/converters/speed/speed.routes.ts
@@ -1,0 +1,8 @@
+import { Routes } from '@angular/router';
+import { SpeedConverterHomePageComponent } from './pages/speed-converter-home-page/speed-converter-home-page.component';
+import { SpeedConverterPageComponent } from './pages/speed-converter-page/speed-converter-page.component';
+
+export const SPEED_ROUTES: Routes = [
+    { path: '', component: SpeedConverterHomePageComponent },
+    { path: ':conversion', component: SpeedConverterPageComponent }
+];


### PR DESCRIPTION
## Summary
This PR adds a complete speed unit converter module to the application, including a home page displaying all available speed unit conversions and a detailed converter page for specific unit pairs.

## Key Changes
- **New Speed Converter Module**: Created `src/converters/speed/` directory with routing configuration
- **Home Page Component**: `SpeedConverterHomePageComponent` displays:
  - Grouped conversion links organized by source unit
  - Quick navigation chips for jumping to unit sections
  - Descriptive content about the speed converter
  - Breadcrumb navigation
- **Converter Page Component**: `SpeedConverterPageComponent` provides:
  - Dynamic conversion between selected speed units
  - Calculator component integration
  - Formula explanation section
  - Comprehensive information about speed units (m/s, km/h, mph, knots, Mach, speed of light, etc.)
  - Breadcrumb navigation with dynamic unit names
- **Routing**: Added speed converter routes to main converters routing configuration
- **UI Updates**: Updated converters page to include speed converter in the category list
- **Styling**: Applied shared converter styles to both components
- **Tests**: Added basic spec files for both components

## Implementation Details
- Both components extend base classes (`ConverterHomePageBase` and `ConverterPageBase`) for consistent functionality
- Uses `UnitConverterFactory` from devtoolz-library for unit conversion logic
- Implements SEO metadata (title, description, keywords) for both pages
- Supports dynamic URL generation for conversion pairs using `unitUrlFormatterService`
- Includes 10 different speed units with detailed explanations and conversion information

https://claude.ai/code/session_01KreicMpFW3RJN78JMzE6p6