### PR TITLE
Add power unit converter module with home and conversion pages

### DIFF
--- a/src/converters/power/pages/power-converter-home-page/power-converter-home-page.component.html
+++ b/src/converters/power/pages/power-converter-home-page/power-converter-home-page.component.html
@@ -1,0 +1,64 @@
+<div class="page-container">
+    <!-- Breadcrumbs -->
+    <nav class="breadcrumbs">
+        <ol>
+            <li><a routerLink="/">Início</a></li>
+            <li><a routerLink="/conversores">Conversores</a></li>
+            <li><span>Potência</span></li>
+        </ol>
+    </nav>
+
+    <!-- Título da Subcategoria -->
+    <div class="category-header">
+        <div class="category-icon">
+            <span class="material-symbols-outlined">bolt</span>
+        </div>
+        <div class="category-info">
+            <h1>Conversor de Potência</h1>
+            <p>Faça conversões precisas entre diferentes unidades de potência</p>
+        </div>
+    </div>
+
+    <!-- Descrição da Subcategoria -->
+    <section class="category-description">
+        <div class="description-content">
+            <p>O conversor de potência permite transformar valores entre diversas unidades, como Watt, Quilowatt,
+                Cavalo-vapor (EUA), Libra-pé por minuto e BTU por minuto, com total precisão e confiabilidade.</p>
+            <p>Ideal para estudantes, profissionais de física, engenharia elétrica, mecânica ou qualquer pessoa que
+                precise converter potências entre diferentes sistemas de medição.</p>
+        </div>
+    </section>
+
+    <!-- Links de conversão agrupados por unidade de medida -->
+    <section class="conversion-groups-container">
+        @for(item of groupedUnits; track item.key.id) {
+        <section class="conversion-group" [id]="item.key.id">
+            <h2>Conversões de {{item.key.name}} ({{item.key.symbol}})</h2>
+            <hr>
+            <div class="conversion-links-grid">
+                @for(unit of item.units; track unit.id) {
+                <a [routerLink]="['/conversores/potencia', unitUrlFormatterService.generateConversionUrl(item.key.id, unit.id)]"
+                    class="conversion-link-card">
+                    <div class="conversion-link-icon">
+                        <span class="material-symbols-outlined">bolt</span>
+                    </div>
+                    <div class="conversion-link-content">
+                        <h3>{{item.key.name}} para {{ unit.name }}</h3>
+                    </div>
+                </a>
+                }
+            </div>
+        </section>
+        }
+    </section>
+
+    <!-- Índice de navegação rápida -->
+    <section class="quick-navigation">
+        <h2>Navegação Rápida</h2>
+        <div class="quick-nav-list">
+            @for(item of groupedUnits; track item.key.id){
+            <a [href]="'#' + item.key.id" class="unit-chip">{{item.key.name}}</a>
+            }
+        </div>
+    </section>
+</div>

--- a/src/converters/power/pages/power-converter-home-page/power-converter-home-page.component.scss
+++ b/src/converters/power/pages/power-converter-home-page/power-converter-home-page.component.scss
@@ -1,0 +1,1 @@
+@import url('../../../shared/converter.style.scss');

--- a/src/converters/power/pages/power-converter-home-page/power-converter-home-page.component.spec.ts
+++ b/src/converters/power/pages/power-converter-home-page/power-converter-home-page.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PowerConverterHomePageComponent } from './power-converter-home-page.component';
+
+describe('PowerConverterHomePageComponent', () => {
+  let component: PowerConverterHomePageComponent;
+  let fixture: ComponentFixture<PowerConverterHomePageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PowerConverterHomePageComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(PowerConverterHomePageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/converters/power/pages/power-converter-home-page/power-converter-home-page.component.ts
+++ b/src/converters/power/pages/power-converter-home-page/power-converter-home-page.component.ts
@@ -1,0 +1,36 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { ConverterHomePageBase } from 'src/converters/shared/pages/converter-home-page-base';
+
+@Component({
+  selector: 'power-converter-home-page',
+  standalone: true,
+  imports: [
+    RouterModule,
+    CommonModule,
+  ],
+  templateUrl: './power-converter-home-page.component.html',
+  styleUrl: './power-converter-home-page.component.scss'
+})
+export class PowerConverterHomePageComponent extends ConverterHomePageBase implements OnInit {
+  constructor() {
+    super("power");
+  }
+
+  ngOnInit() {
+    const pageTitle = 'Conversor de Potência';
+    const description = 'Converta facilmente entre diferentes unidades de potência como Watt, Quilowatt, Cavalo-vapor (EUA), Libra-pé por minuto e BTU por minuto. Calculadora precisa com explicações detalhadas e conversões confiáveis.';
+    const keywords = 'conversor de potência, watt, quilowatt, cavalo-vapor, horsepower, hp, btu por minuto, libra-pé por minuto, conversão de potência, calculadora de potência';
+
+    this.onInit(
+      pageTitle,
+      description,
+      keywords,
+    );
+  }
+
+  ngAfterViewInit() {
+    this.navigationHelper();
+  }
+}

--- a/src/converters/power/pages/power-converter-page/power-converter-page.component.html
+++ b/src/converters/power/pages/power-converter-page/power-converter-page.component.html
@@ -1,0 +1,73 @@
+<div class="page-container">
+  <nav class="breadcrumbs">
+    <ol>
+      <li><a routerLink="/">Início</a></li>
+      <li><a routerLink="/conversores">Conversores</a></li>
+      <li><a routerLink="/conversores/potencia">Potência</a></li>
+      <li><span>Converter {{selectedSourceUnit.name}} para {{selectedTargetUnit.name}}</span></li>
+    </ol>
+  </nav>
+
+  <converter-title [sourceUnit]="selectedSourceUnit" [targetUnit]="selectedTargetUnit" />
+
+  <!-- Instruções de uso -->
+  <div class="card mb-4">
+    <div class="card-body">
+      <h2 class="card-title fs-4">
+        Como usar a ferramenta de conversão de {{selectedSourceUnit.name.toLowerCase()}} para
+        {{selectedTargetUnit.name.toLowerCase()}}
+      </h2>
+      <p>
+        Esta calculadora permite converter entre diversas unidades de potência, incluindo Watt, Quilowatt,
+        Cavalo-vapor (EUA), Libra-pé por minuto e BTU por minuto. Basta selecionar as unidades de origem e destino,
+        inserir o valor desejado e o sistema calculará automaticamente o resultado com base nos fatores de conversão
+        apropriados.
+      </p>
+      <ol>
+        <li>Escolha a unidade de origem (de onde deseja converter)</li>
+        <li>Escolha a unidade de destino (para onde deseja converter)</li>
+        <li>Digite o valor na unidade de origem</li>
+        <li>O resultado será calculado automaticamente</li>
+      </ol>
+    </div>
+  </div>
+
+  <!-- Componente de calculadora -->
+  <calculator [selectedCategoryId]="selectedCategory" [selectedSourceUnitId]="selectedSourceUnit.id"
+    [selectedTargetUnitId]="selectedTargetUnit.id" (sourceUnitChange)="onSourceUnitChange($event)"
+    (targetUnitChange)="onTargetUnitChange($event)" (valueChange)="onValueChange($event)">
+  </calculator>
+
+  <!-- Explicação da fórmula de cálculo -->
+  <div class="mt-5 card" *ngIf="showFormula">
+    <div class="card-body">
+      <h2 class="card-title fs-4">Explicação do Cálculo</h2>
+      <p>{{ formulaDescription }}</p>
+      <div class="bg-dark text-light p-3 rounded">
+        <pre class="mb-0">{{ formulaCalculation }}</pre>
+      </div>
+    </div>
+  </div>
+
+  <!-- Informações adicionais -->
+  <div class="mt-5">
+    <h2 class="text-center fs-4">Informações sobre Unidades de Potência</h2>
+    <div class="texto-explicativo">
+      <p>
+        A potência é a grandeza física que mede a taxa de realização de trabalho ou transferência de energia por
+        unidade de tempo. Existem diferentes unidades utilizadas para medir potência ao redor do mundo:
+      </p>
+      <ul>
+        <li><strong>Watt (W)</strong>: unidade padrão do Sistema Internacional de Unidades (SI); equivale a 1 Joule por segundo</li>
+        <li><strong>Quilowatt (kW)</strong>: equivale a 1.000 Watts; amplamente utilizado para expressar a potência de motores e aparelhos elétricos</li>
+        <li><strong>Cavalo-vapor (EUA) (hp)</strong>: unidade do sistema imperial norte-americano; 1 hp ≈ 745,7 W; comumente usada para especificar a potência de veículos e motores</li>
+        <li><strong>Libra-pé por minuto (lbf·ft/min)</strong>: unidade do sistema imperial que mede trabalho realizado por unidade de tempo; 1 lbf·ft/min ≈ 0,02260 W</li>
+        <li><strong>BTU por minuto (BTU/min)</strong>: unidade térmica britânica por minuto; utilizada em sistemas de aquecimento e refrigeração; 1 BTU/min ≈ 17,58 W</li>
+      </ul>
+      <p>
+        Todas as conversões são realizadas com alta precisão, utilizando o Watt como unidade base conforme o
+        Sistema Internacional de Unidades.
+      </p>
+    </div>
+  </div>
+</div>

--- a/src/converters/power/pages/power-converter-page/power-converter-page.component.scss
+++ b/src/converters/power/pages/power-converter-page/power-converter-page.component.scss
@@ -1,0 +1,1 @@
+@import url('../../../shared/converter.style.scss');

--- a/src/converters/power/pages/power-converter-page/power-converter-page.component.spec.ts
+++ b/src/converters/power/pages/power-converter-page/power-converter-page.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PowerConverterPageComponent } from './power-converter-page.component';
+
+describe('PowerConverterPageComponent', () => {
+  let component: PowerConverterPageComponent;
+  let fixture: ComponentFixture<PowerConverterPageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PowerConverterPageComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(PowerConverterPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/converters/power/pages/power-converter-page/power-converter-page.component.ts
+++ b/src/converters/power/pages/power-converter-page/power-converter-page.component.ts
@@ -1,0 +1,32 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+import { CalculatorComponent } from 'src/converters/shared/components/calculator/calculator.component';
+import { ConverterPageBase } from 'src/converters/shared/pages/converter-page-base';
+import { ConverterTitleComponent } from "src/converters/shared/components/converter-title/converter-title.component";
+
+@Component({
+  selector: 'power-converter-page',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    RouterModule,
+    CalculatorComponent,
+    ConverterTitleComponent
+  ],
+  templateUrl: './power-converter-page.component.html',
+  styleUrl: './power-converter-page.component.scss'
+})
+export class PowerConverterPageComponent extends ConverterPageBase implements OnInit {
+  constructor() {
+    super("power", "potencia");
+    this.setTitle('Conversor de Potência');
+    this.addDescription('Ferramenta para converter entre diferentes unidades de potência como Watt, Quilowatt, Cavalo-vapor (EUA), Libra-pé por minuto e BTU por minuto. Conversão precisa, instantânea e confiável.');
+  }
+
+  ngOnInit(): void {
+    this.onInit('watt', 'quilowatt');
+  }
+}

--- a/src/converters/power/power.routes.ts
+++ b/src/converters/power/power.routes.ts
@@ -1,0 +1,8 @@
+import { Routes } from '@angular/router';
+import { PowerConverterHomePageComponent } from './pages/power-converter-home-page/power-converter-home-page.component';
+import { PowerConverterPageComponent } from './pages/power-converter-page/power-converter-page.component';
+
+export const POWER_ROUTES: Routes = [
+    { path: '', component: PowerConverterHomePageComponent },
+    { path: ':conversion', component: PowerConverterPageComponent }
+];

--- a/src/converters/shared/converters.routes.ts
+++ b/src/converters/shared/converters.routes.ts
@@ -17,4 +17,5 @@ export const CONVERTERS_ROUTES: Routes = [
     { path: 'angulo', loadChildren: () => import('../angle/angle.routes').then(m => m.ANGLE_ROUTES) },
     { path: 'pressao', loadChildren: () => import('../pressure/pressure.routes').then(m => m.PRESSURE_ROUTES) },
     { path: 'velocidade', loadChildren: () => import('../speed/speed.routes').then(m => m.SPEED_ROUTES) },
+    { path: 'potencia', loadChildren: () => import('../power/power.routes').then(m => m.POWER_ROUTES) },
 ];


### PR DESCRIPTION
## Summary
This PR adds a complete power unit converter module to the application, enabling users to convert between different power units such as Watt, Kilowatt, Horsepower (US), Pound-force per minute, and BTU per minute.

## Key Changes
- **New Power Converter Module**: Created `src/converters/power/` directory with complete converter implementation
- **Home Page Component**: Added `PowerConverterHomePageComponent` that displays:
  - Category header with icon and description
  - Grouped conversion links organized by source unit
  - Quick navigation section for easy access to different unit conversions
- **Converter Page Component**: Added `PowerConverterPageComponent` that provides:
  - Breadcrumb navigation
  - Converter title component
  - Usage instructions for the conversion tool
  - Calculator component for performing conversions
  - Formula explanation section
  - Detailed information about power units and their definitions
- **Routing**: Added `power.routes.ts` with routes for home page and dynamic conversion routes
- **Styling**: Added SCSS files that import shared converter styles
- **Unit Tests**: Added spec files for both page components
- **Module Integration**: Updated `converters.routes.ts` to include the new power converter routes

## Implementation Details
- Both components extend base classes (`ConverterHomePageBase` and `ConverterPageBase`) for shared functionality
- Components are standalone Angular components with proper imports
- SEO metadata is configured with page titles, descriptions, and keywords
- The converter supports 5 power units with proper conversion factors based on SI standards
- UI includes breadcrumbs, icons, and responsive grid layouts for conversion links

https://claude.ai/code/session_01TGn9WMHtDXhTSprznqRpwm