### PR TITLE
fix: restringir campo morse para aceitar apenas '.', '-' e espaço

### DIFF
--- a/src/converters/text-converter/pages/text-converter-page/text-converter-page.component.html
+++ b/src/converters/text-converter/pages/text-converter-page/text-converter-page.component.html
@@ -49,6 +49,7 @@
                     class="value-input"
                     [(ngModel)]="sourceValue"
                     (ngModelChange)="onSourceValueChange()"
+                    (input)="onSourceInputEvent($event)"
                     [placeholder]="sourcePlaceholder"
                     autocomplete="off"
                     spellcheck="false"

--- a/src/converters/text-converter/pages/text-converter-page/text-converter-page.component.ts
+++ b/src/converters/text-converter/pages/text-converter-page/text-converter-page.component.ts
@@ -84,10 +84,23 @@ export class TextConverterPageComponent extends PageBase implements OnInit {
     }
 
     onSourceValueChange(): void {
-        if (this.sourceFormat?.id === 'morse') {
-            this.sourceValue = this._sanitizeMorseInput(this.sourceValue);
-        }
         this._convert();
+    }
+
+    onSourceInputEvent(event: Event): void {
+        if (this.sourceFormat?.id !== 'morse') return;
+
+        const textarea = event.target as HTMLTextAreaElement;
+        const filtered = this._sanitizeMorseInput(textarea.value);
+
+        if (filtered !== textarea.value) {
+            const cursorPos = textarea.selectionStart ?? filtered.length;
+            textarea.value = filtered;
+            this.sourceValue = filtered;
+            const newCursor = Math.min(cursorPos, filtered.length);
+            textarea.setSelectionRange(newCursor, newCursor);
+            this._convert();
+        }
     }
 
     get sourcePlaceholder(): string {


### PR DESCRIPTION
## Resumo

- O campo de entrada do código morse estava aceitando qualquer caractere além dos válidos para o formato morse
- Adicionado método `_sanitizeMorseInput` que filtra o valor removendo qualquer caractere que não seja ponto (`.`), hífen (`-`) ou espaço (` `)
- O filtro é aplicado via evento nativo `(input)` manipulando diretamente o `HTMLTextAreaElement`, garantindo que a atualização do DOM ocorra em tempo real — inclusive ao colar texto

Closes #166

## Plano de testes

- [ ] Selecionar "Código Morse" como formato de origem no conversor de texto
- [ ] Tentar digitar letras, números e caracteres especiais — nenhum deve aparecer no campo
- [ ] Verificar que `.`, `-` e ` ` (espaço) são aceitos normalmente
- [ ] Colar texto com caracteres inválidos — devem ser removidos automaticamente
- [ ] Confirmar que a conversão morse → texto continua funcionando corretamente