### PR TITLE
Add binary input sanitization to text converter

### DIFF
--- a/src/converters/text-converter/pages/text-converter-page/text-converter-page.component.ts
+++ b/src/converters/text-converter/pages/text-converter-page/text-converter-page.component.ts
@@ -88,10 +88,15 @@ export class TextConverterPageComponent extends PageBase implements OnInit {
     }
 
     onSourceInputEvent(event: Event): void {
-        if (this.sourceFormat?.id !== 'morse') return;
+        const isMorse = this.sourceFormat?.id === 'morse';
+        const isBinary = this.sourceFormat?.id === 'binario';
+
+        if (!isMorse && !isBinary) return;
 
         const textarea = event.target as HTMLTextAreaElement;
-        const filtered = this._sanitizeMorseInput(textarea.value);
+        const filtered = isMorse
+            ? this._sanitizeMorseInput(textarea.value)
+            : this._sanitizeBinaryInput(textarea.value);
 
         if (filtered !== textarea.value) {
             const cursorPos = textarea.selectionStart ?? filtered.length;
@@ -118,6 +123,10 @@ export class TextConverterPageComponent extends PageBase implements OnInit {
 
     private _sanitizeMorseInput(value: string): string {
         return value.replace(/[^.\- ]/g, '');
+    }
+
+    private _sanitizeBinaryInput(value: string): string {
+        return value.replace(/[^01 ]/g, '');
     }
 
     private _isValidPair(sourceId: string, targetId: string): boolean {


### PR DESCRIPTION
## Summary
Extended the text converter's input sanitization functionality to support binary format in addition to morse code. The input event handler now filters invalid characters for both morse and binary formats.

## Key Changes
- Modified `onSourceInputEvent()` to handle both morse and binary source formats
- Added `_sanitizeBinaryInput()` method that removes all characters except '0', '1', and spaces
- Updated conditional logic to process input sanitization for either morse or binary formats based on the selected source format
- Maintained cursor position restoration behavior for both format types

## Implementation Details
- Binary input sanitization uses regex pattern `/[^01 ]/g` to keep only binary digits and spaces
- The handler now checks for both morse (`'morse'`) and binary (`'binario'`) format IDs before applying sanitization
- Conditional ternary operator determines which sanitization method to apply based on the source format

https://claude.ai/code/session_01QpYczXzYQF8NTxfzSEHUkt