### PR TITLE
Fix layout height to use viewport units instead of percentage

### DIFF
--- a/src/shared/pages/main-layout/main-layout.component.scss
+++ b/src/shared/pages/main-layout/main-layout.component.scss
@@ -2,6 +2,7 @@
     display: flex;
     flex-direction: column;
     width: 100%;
+    min-height: 100vh;
 }
 
 .main-content {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -63,10 +63,16 @@ h6 {
     color: #4caf50 !important;
 }
 
+html,
+body {
+    height: 100%;
+    min-height: 100vh;
+}
+
 main-layout {
     display: flex;
     width: 100%;
-    height: 100%;
+    min-height: 100vh;
 }
 
 .page-container {


### PR DESCRIPTION
## Summary
Updated the global layout styling to use viewport height units (`100vh`) instead of percentage-based height (`100%`) to ensure proper full-height layout rendering across different viewport scenarios.

## Key Changes
- Added `html` and `body` height rules with `height: 100%` and `min-height: 100vh` to establish a proper height baseline
- Changed `main-layout` component from `height: 100%` to `min-height: 100vh` for consistent viewport coverage
- Added `min-height: 100vh` to the main layout component's SCSS file to match the global styling approach

## Implementation Details
This change addresses a common CSS layout issue where percentage-based heights don't work as expected without explicit parent heights. By using `min-height: 100vh` on key layout components, the layout will:
- Always fill at least the full viewport height
- Properly expand if content exceeds viewport height
- Work consistently across different browsers and devices

https://claude.ai/code/session_01FDZh6NcFpABBiKjtm3pgHr