### PR TITLE
Refactor weight-mass converter page layout structure

### DIFF
--- a/src/converters/weight-and-mass/pages/weight-mass-converter-page/weight-mass-converter-page.component.html
+++ b/src/converters/weight-and-mass/pages/weight-mass-converter-page/weight-mass-converter-page.component.html
@@ -1,130 +1,73 @@
 <div class="page-container">
-  <div class="text-center mb-5">
-    <nav class="breadcrumbs">
+  <nav class="breadcrumbs">
+    <ol>
+      <li><a routerLink="/">Início</a></li>
+      <li><a routerLink="/conversores">Conversores</a></li>
+      <li><a routerLink="/conversores/peso-e-massa">Peso e Massa</a></li>
+      <li><span>Converter {{selectedSourceUnit.name}} para {{selectedTargetUnit.name}}</span></li>
+    </ol>
+  </nav>
+
+  <converter-title [sourceUnit]="selectedSourceUnit" [targetUnit]="selectedTargetUnit" />
+
+  <!-- Instruções de uso -->
+  <div class="card mb-4">
+    <div class="card-body">
+      <h2 class="card-title fs-4">
+        Como usar a ferramenta de conversão de {{selectedSourceUnit.name.toLowerCase()}} para
+        {{selectedTargetUnit.name.toLowerCase()}}
+      </h2>
+      <p>
+        Esta calculadora permite converter entre diversas unidades de peso e massa, incluindo medidas métricas e
+        imperiais. Basta selecionar as unidades de origem e destino, e inserir o valor a ser convertido.
+      </p>
       <ol>
-        <li><a routerLink="/">Início</a></li>
-        <li><a routerLink="/conversores">Conversores</a></li>
-        <li><a routerLink="/conversores/peso-e-massa">Peso e Massa</a></li>
-        <li><span>Converter {{selectedSourceUnit.name}} para {{selectedTargetUnit.name}}</span></li>
+        <li>Escolha a unidade de origem (de onde deseja converter)</li>
+        <li>Escolha a unidade de destino (para onde deseja converter)</li>
+        <li>Digite o valor na unidade de origem</li>
+        <li>O resultado será calculado automaticamente</li>
       </ol>
-    </nav>
-
-    <converter-title [sourceUnit]="selectedSourceUnit" [targetUnit]="selectedTargetUnit" />
-
-    <!-- Instruções de uso -->
-    <div class="card mb-4">
-      <div class="card-body">
-        <h2 class="card-title fs-4">
-          Como usar a ferramenta de conversão de {{selectedSourceUnit.name.toLowerCase()}} para
-          {{selectedTargetUnit.name.toLowerCase()}}
-        </h2>
-        <p>
-          Esta calculadora permite converter entre diversas unidades de peso e massa, incluindo medidas métricas e
-          imperiais. Basta selecionar as unidades de origem e destino, e inserir o valor a ser convertido.
-        </p>
-        <ol>
-          <li>Escolha a unidade de origem (de onde deseja converter)</li>
-          <li>Escolha a unidade de destino (para onde deseja converter)</li>
-          <li>Digite o valor na unidade de origem</li>
-          <li>O resultado será calculado automaticamente</li>
-        </ol>
-      </div>
     </div>
+  </div>
 
-    <!-- Componente de calculadora -->
-    <calculator [selectedCategoryId]="selectedCategory" [selectedSourceUnitId]="selectedSourceUnit.id"
-      [selectedTargetUnitId]="selectedTargetUnit.id" (sourceUnitChange)="onSourceUnitChange($event)"
-      (targetUnitChange)="onTargetUnitChange($event)" (valueChange)="onValueChange($event)">
-    </calculator>
+  <!-- Componente de calculadora -->
+  <calculator [selectedCategoryId]="selectedCategory" [selectedSourceUnitId]="selectedSourceUnit.id"
+    [selectedTargetUnitId]="selectedTargetUnit.id" (sourceUnitChange)="onSourceUnitChange($event)"
+    (targetUnitChange)="onTargetUnitChange($event)" (valueChange)="onValueChange($event)">
+  </calculator>
 
-    <!-- Explicação da fórmula de cálculo -->
-    <div class="mt-5 card" *ngIf="showFormula">
-      <div class="card-body">
-        <h2 class="card-title fs-4">Explicação do Cálculo</h2>
-        <p>{{ formulaDescription }}</p>
-        <div class="bg-dark text-light p-3 rounded">
-          <pre class="mb-0">{{ formulaCalculation }}</pre>
-        </div>
-      </div>
-    </div>
-
-    <!-- Links para conversões populares -->
-    <!-- <div class="mt-5">
-      <h2 class="text-center fs-4">Conversões Populares</h2>
-      <div class="row g-3 mt-2">
-        <div class="col-12 col-sm-6 col-md-4 col-lg-3" *ngFor="let conversao of conversoesSugeridas">
-          <a [routerLink]="['/conversores/peso-massa', conversao.url]" class="text-decoration-none">
-            <div class="card h-100 conversion-card">
-              <div class="card-body d-flex align-items-center justify-content-center text-center">
-                <span class="material-symbols-outlined me-2">swap_horiz</span>
-                {{ conversao.nome }}
-              </div>
-            </div>
-          </a>
-        </div>
-      </div>
-    </div> -->
-
-    <!-- Seção de links para outros conversores (comentada por enquanto) -->
-    <!--
-    <div class="mt-5">
-      <h2 class="text-center fs-4">Outros Conversores</h2>
-      <div class="row g-3 mt-2">
-        <div class="col-12 col-sm-6 col-md-4">
-          <a routerLink="/conversores/comprimento" class="text-decoration-none">
-            <div class="card h-100 converter-card">
-              <div class="card-body d-flex align-items-center justify-content-center text-center">
-                <span class="material-symbols-outlined me-2">straighten</span>
-                Conversor de Comprimento
-              </div>
-            </div>
-          </a>
-        </div>
-        <div class="col-12 col-sm-6 col-md-4">
-          <a routerLink="/conversores/volume" class="text-decoration-none">
-            <div class="card h-100 converter-card">
-              <div class="card-body d-flex align-items-center justify-content-center text-center">
-                <span class="material-symbols-outlined me-2">water_full</span>
-                Conversor de Volume
-              </div>
-            </div>
-          </a>
-        </div>
-        <div class="col-12 col-sm-6 col-md-4">
-          <a routerLink="/conversores/temperatura" class="text-decoration-none">
-            <div class="card h-100 converter-card">
-              <div class="card-body d-flex align-items-center justify-content-center text-center">
-                <span class="material-symbols-outlined me-2">device_thermostat</span>
-                Conversor de Temperatura
-              </div>
-            </div>
-          </a>
-        </div>
-      </div>
-    </div>
-    -->
-
-    <!-- Informações adicionais -->
-    <div class="mt-5">
-      <h2 class="text-center fs-4">Informações sobre Unidades de Peso e Massa</h2>
-      <div class="texto-explicativo">
-        <p>
-          Peso e massa são conceitos distintos, embora frequentemente utilizados de maneira intercambiável no dia a
-          dia.
-          A massa é a quantidade de matéria em um objeto, enquanto o peso é a força gravitacional exercida sobre essa
-          massa.
-          Existem diversos sistemas de medição de peso e massa em uso ao redor do mundo:
-        </p>
-        <ul>
-          <li><strong>Sistema Internacional (SI)</strong>: Grama (g), Quilograma (kg), Tonelada métrica (t)</li>
-          <li><strong>Sistema Imperial</strong>: Onça (oz), Libra (lb), Pedra (st), Toneladas (curta e longa)</li>
-          <li><strong>Outras unidades</strong>: Quilates (para gemas e metais preciosos), Grão (usado em farmácia e
-            balística)</li>
-        </ul>
-        <p>
-          Todos os cálculos são realizados com alta precisão usando fatores de conversão padrão.
-          A unidade base utilizada para todas as conversões é o grama (g).
-        </p>
+  <!-- Explicação da fórmula de cálculo -->
+  <div class="mt-5 card" *ngIf="showFormula">
+    <div class="card-body">
+      <h2 class="card-title fs-4">Explicação do Cálculo</h2>
+      <p>{{ formulaDescription }}</p>
+      <div class="bg-dark text-light p-3 rounded">
+        <pre class="mb-0">{{ formulaCalculation }}</pre>
       </div>
     </div>
   </div>
+
+  <!-- Informações adicionais -->
+  <div class="mt-5">
+    <h2 class="text-center fs-4">Informações sobre Unidades de Peso e Massa</h2>
+    <div class="texto-explicativo">
+      <p>
+        Peso e massa são conceitos distintos, embora frequentemente utilizados de maneira intercambiável no dia a
+        dia.
+        A massa é a quantidade de matéria em um objeto, enquanto o peso é a força gravitacional exercida sobre essa
+        massa.
+        Existem diversos sistemas de medição de peso e massa em uso ao redor do mundo:
+      </p>
+      <ul>
+        <li><strong>Sistema Internacional (SI)</strong>: Grama (g), Quilograma (kg), Tonelada métrica (t)</li>
+        <li><strong>Sistema Imperial</strong>: Onça (oz), Libra (lb), Pedra (st), Toneladas (curta e longa)</li>
+        <li><strong>Outras unidades</strong>: Quilates (para gemas e metais preciosos), Grão (usado em farmácia e
+          balística)</li>
+      </ul>
+      <p>
+        Todos os cálculos são realizados com alta precisão usando fatores de conversão padrão.
+        A unidade base utilizada para todas as conversões é o grama (g).
+      </p>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
Refactored the weight and mass converter page template to improve layout structure and remove unnecessary wrapper divs. The changes simplify the DOM hierarchy while maintaining all functionality and content.

## Key Changes
- Removed the outer `text-center mb-5` wrapper div that was centering all content
- Moved the breadcrumb navigation outside the centered container to the top level
- Adjusted indentation and spacing of all child elements to reflect the new structure
- Removed commented-out sections for popular conversions and other converters links
- Maintained all functional components: converter title, calculator, formula explanation, and informational sections

## Implementation Details
- The page now uses a flatter DOM structure with the `page-container` as the direct parent
- All content sections (breadcrumbs, title, instructions, calculator, formula, and info) are now direct children of the page container
- No changes to component logic, styling classes, or functionality - this is purely a structural refactoring
- The closing `</div>` tag for `page-container` was added to properly close the container

https://claude.ai/code/session_013Knr5CmXrdMKFRNqVnf1aC