### PR TITLE
Fix reqHandler to invoke app function instead of passing reference

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -47,4 +47,4 @@ if (isMainModule(import.meta.url)) {
   run();
 }
 
-export const reqHandler = createNodeRequestHandler(app);
+export const reqHandler = createNodeRequestHandler(app());


### PR DESCRIPTION
## Summary
Fixed the request handler export to properly invoke the `app` function rather than passing a function reference to `createNodeRequestHandler`.

## Key Changes
- Changed `createNodeRequestHandler(app)` to `createNodeRequestHandler(app())` to invoke the app function and pass its return value instead of the function itself

## Implementation Details
This change ensures that the Express/Node application instance is properly initialized and passed to the request handler, rather than passing the app factory function. This is necessary for the request handler to correctly process incoming requests.

https://claude.ai/code/session_019hDzJXe839E8YGi8W3K4Ff